### PR TITLE
Read/Write File Buffers to Disk

### DIFF
--- a/server/include/file_handler.h
+++ b/server/include/file_handler.h
@@ -1,0 +1,34 @@
+#include <fstream>
+#include <string>
+
+namespace lft {
+class FileHander {
+ public:
+  long GetFileSize(std::ifstream* file) {
+    file->seekg(0, file->end);
+    long size = file->tellg();
+    file->seekg(0);
+    return size;
+  }
+
+  long GetFileSize(const std::string& file_name) {
+    std::ifstream file(file_name, std::ifstream::binary);
+    long size = GetFileSize(&file);
+    file.close();
+    return size;
+  }
+
+  void WriteBufferToFile(char* buffer, long size, const std::string& file_name) {
+    std::ofstream file_to_create(file_name, std::ofstream::binary);
+    file_to_create.write(buffer, size);
+    file_to_create.close();
+  }
+
+  void WriteFileToBuffer(char* buffer, const std::string& file_name) {
+    std::ifstream file_to_read(file_name, std::ifstream::binary);
+    long size = GetFileSize(&file_to_read);
+    file_to_read.read(buffer, size);
+    file_to_read.close();
+  }
+};
+}  // namespace lft


### PR DESCRIPTION
Resolves #30

The `lft::FileHandler` class allows us to read from / write to disk with `char*` buffers. This class can be tested with the below code:

```cpp
  lft::FileHander fh;
  std::ifstream infile("test.txt", std::ifstream::binary);
  long size = fh.GetFileSize(&infile);
  char* buffer_to_write = new char[size];
  infile.read(buffer_to_write, size);

  // use a buffer with existing data and write it to a file
  // for example, an http request with file data in the body
  fh.WriteBufferToFile(buffer_to_write, size, "test_copy.txt");
  infile.close();

  size = fh.GetFileSize("sound.mp4");
  char* file_data_buffer = new char[size];
  // save a file's data to a buffer
  // for example, return a desired files data as an http response
  fh.WriteFileToBuffer(file_data_buffer, "sound.mp4");
  
  // i wrote the below code just to demonstrate the buffer does have the data
  std::ofstream outfile("sound_copy.mp4", std::ofstream::binary);
  outfile.write(file_data_buffer, size);
  outfile.close();

  // cleanup
  delete buffer_to_write;
  delete file_data_buffer;
```

need to come up with logic for if a file to read doesn't exist.