### PR TITLE
Add File Saving to C++ Service

### DIFF
--- a/server/include/file_handler.h
+++ b/server/include/file_handler.h
@@ -2,29 +2,43 @@
 #include <string>
 
 namespace lft {
-class FileHander {
+constexpr char kBeginningOfContentBorder[] = "\r\n\r\n";
+constexpr char kEndOfContentBorder[] = "----------------------------";
+constexpr uint8_t kBeginningOfContentOffset = 4;
+constexpr uint8_t kEndOfContentOffset = 2;
+
+class FileHandler {
  public:
-  long GetFileSize(std::ifstream* file) {
+  long GetFileSize(std::ifstream *file) {
     file->seekg(0, file->end);
     long size = file->tellg();
     file->seekg(0);
     return size;
   }
 
-  long GetFileSize(const std::string& file_name) {
+  long GetFileSize(const std::string &file_name) {
     std::ifstream file(file_name, std::ifstream::binary);
     long size = GetFileSize(&file);
     file.close();
     return size;
   }
 
-  void WriteBufferToFile(char* buffer, long size, const std::string& file_name) {
-    std::ofstream file_to_create(file_name, std::ofstream::binary);
+  void ParseAndWriteHttpRequestBody(const std::string& request_body) {
+      size_t position = request_body.find(kBeginningOfContentBorder);
+      std::string parsed_body = request_body.substr(position + kBeginningOfContentOffset);
+      position = parsed_body.rfind(kEndOfContentBorder);
+      parsed_body.erase(position - kEndOfContentOffset);
+      WriteBufferToFile(parsed_body.c_str(), parsed_body.size(), "output");
+  }
+
+  void WriteBufferToFile(const char *buffer, long size,
+                         const std::string &file_name) {
+    std::ofstream file_to_create(file_name, std::ios::out);
     file_to_create.write(buffer, size);
     file_to_create.close();
   }
 
-  void WriteFileToBuffer(char* buffer, const std::string& file_name) {
+  void WriteFileToBuffer(char *buffer, const std::string &file_name) {
     std::ifstream file_to_read(file_name, std::ifstream::binary);
     long size = GetFileSize(&file_to_read);
     file_to_read.read(buffer, size);

--- a/server/include/http_server.h
+++ b/server/include/http_server.h
@@ -2,45 +2,12 @@
 
 #include <sys/time.h>
 
+#include <fstream>
+#include <iostream>
 #include <string>
 
-#include "cpprest/http_listener.h"
-#include "cpprest/uri.h"
-#include "gridfs_handler.h"
-#include "mongocxx/uri.hpp"
+#include "file_handler.h"
 
 namespace lft {
-class HttpServer {
- public:
-  static constexpr char kFindFileUri[] = "/find";
-  static constexpr char kUploadFileUri[] = "/upload";
-  static constexpr char kFaviconUri[] = "/favicon.ico";
-  explicit HttpServer(const utility::string_t& url) {
-    message_listener = web::http::experimental::listener::http_listener(url);
-    message_listener.support(
-        web::http::methods::GET,
-        std::bind(&HttpServer::HandleGet, this, std::placeholders::_1));
-  }
-  pplx::task<void> open() { return message_listener.open(); }
-  pplx::task<void> close() { return message_listener.close(); }
-
- private:
-  void HandleGet(const web::http::http_request& message) {
-    const std::string& uri = message.absolute_uri().to_string();
-    if (uri == kFaviconUri) {
-      message.reply(web::http::status_codes::NotFound);
-      return;
-    }
-    const mongocxx::v_noabi::uri mongo_uri = mongocxx::v_noabi::uri{};
-    GridFsHandler gridfs_handler(mongo_uri);
-    if (uri == kFindFileUri) {
-      gridfs_handler.FindAllFiles();
-    } else if (uri == kUploadFileUri) {
-      gridfs_handler.UploadFile();
-    }
-    message.reply(web::http::status_codes::OK, "nama jeff 2");
-    return;
-  }
-  web::http::experimental::listener::http_listener message_listener;
-};
+class HttpServer {};
 } // namespace lft


### PR DESCRIPTION
Going to localhost:3000/upload with a file uploaded as form-data will have the contents be saved on
the c++ side as a file called "output". Next step is to allow the API Gateway to send a file to this
service instead of using postman.