### PR TITLE
Create base image for C++ logging service

### DIFF
--- a/logging-service/Dockerfile
+++ b/logging-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest as build_stage
+FROM repo.treescale.com/kafumji/lft-mongocxx-base
 
 WORKDIR /cpp_server
 
@@ -24,7 +24,7 @@ RUN mkdir /cpp_server/bin
 
 RUN chmod +x ./setup
 
-RUN ./setup
+RUN ["./setup", "--type", "docker"]
 
 EXPOSE 5002
 

--- a/logging-service/Dockerfile.base
+++ b/logging-service/Dockerfile.base
@@ -1,0 +1,13 @@
+FROM debian:latest as build_stage
+
+WORKDIR /cpp_server
+
+RUN apt-get update \
+  && apt-get install -y wget cmake git make g++ python3 \
+  && apt-get install sudo -y
+
+WORKDIR /cpp_server
+
+COPY setup setup
+
+RUN ["./setup", "--type", "base"]

--- a/logging-service/setup
+++ b/logging-service/setup
@@ -50,11 +50,27 @@ function install_json_dependencies() {
 
 function main() {
   quit_if_script_run_as_root
-  install_mongocxx_dependencies
-  cd lib
-  install_served_dependencies
-  install_json_dependencies
-  cd ..
+  if [[ "$1" == "-t" || "$1" == "--type" && ! -z $2 ]]; then
+    if [ "$2" == "base" ]; then
+      # if we are setting up the base image
+      echo "Installing mongocxx dependencies only..."
+      install_mongocxx_dependencies
+    elif [ "$2" == "docker" ]; then
+      # if we are building the image derived from the base
+      echo "Installing all dependencies except mongocxx..."
+      cd lib
+      install_served_dependencies
+      install_json_dependencies
+      cd ..
+    fi
+  else
+    echo "Defaulting to install all dependencies..."
+    install_mongocxx_dependencies
+    cd lib
+    install_served_dependencies
+    install_json_dependencies
+    cd ..
+  fi
 }
 
-main
+main $1 $2


### PR DESCRIPTION
We now have a base image that is in charge of installing mongocxx. The mongocxx install takes about 10
minutes and no longer has to be done every time I make changes to the logging service.