### PR TITLE
Logging Service Returns JSON Filename

### DIFF
--- a/logging-service/include/http_server.h
+++ b/logging-service/include/http_server.h
@@ -36,11 +36,17 @@ class HttpServer {
   auto LogDownload() {
     return [&](served::response &response, const served::request &request) {
       json::JSON request_body = json::JSON::Load(request.body());
+      const std::string &file_id = request_body["fileId"].ToString();
       MongoDbHandler mhandler;
-      bool update_successful =
-          mhandler.LogDownload(request_body["fileId"].ToString());
-      update_successful ? served::response::stock_reply(200, response)
-                        : served::response::stock_reply(404, response);
+      bool update_successful = mhandler.LogDownload(file_id);
+      if (update_successful) {
+        const json::JSON &all_documents = mhandler.GetFileNameById(file_id);
+        std::ostringstream stream;
+        stream << all_documents;
+        response << stream.str();
+      } else {
+        served::response::stock_reply(404, response);
+      }
     };
   }
 


### PR DESCRIPTION
Part of #59. When we log a download, the logging service now returns a JSON
response containing the name of the file that was downloaded. This is so we can
supply the file name with the file data from the API gateway instead of manually
setting it in the frontend.