### PR TITLE
Use dockerhub instead of treescale for mongocxx-base image

### DIFF
--- a/logging-service/Dockerfile
+++ b/logging-service/Dockerfile
@@ -1,8 +1,8 @@
-FROM repo.treescale.com/kafumji/lft-mongocxx-base
+FROM evanugarte/mongocxx-base
 
 WORKDIR /cpp_server
 
-RUN apt-get update \
+RUN apt-get update --allow-releaseinfo-change \
   && apt-get install -y wget cmake git make g++ curl python3 \
   && apt-get install sudo -y
 


### PR DESCRIPTION
The base image can be found at [evanugarte/mongocxx-base](https://hub.docker.com/repository/docker/evanugarte/mongocxx-base/) and is available for anyone to pull and use.

Also added the `--allow-releaseinfo-change` to the update step to avoid the build erroring out.