### PR TITLE
Change MongoDB container version to 4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - lft-api-gateway
   mongo:
     container_name: mongo-lft
-    image: mongo
+    image: mongo:4.0
     volumes:
       - "~/data/db:/usr/src/app/data/db"
     command: 'mongod'


### PR DESCRIPTION
Using version 4.0 for MongoDB allows for compatibility with older CPUs. Running this project on an old server with version 5 I got the error

```
WARNING: MongoDB 5.0+ requires a CPU with AVX support, and your current system does not appear to have that!
mongo-lft          |   see https://jira.mongodb.org/browse/SERVER-54407
mongo-lft          |   see also https://www.mongodb.com/community/forums/t/mongodb-5-0-cpu-intel-g4650-compatibility/116610/2
mongo-lft          |   see also https://github.com/docker-library/mongo/issues/485#issuecomment-891991814
```
